### PR TITLE
Split Data East 99(a.k.a ACE) chip emulation

### DIFF
--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -1542,6 +1542,8 @@ files {
 	MAME_DIR .. "src/mame/machine/decocpu7.h",
 	MAME_DIR .. "src/mame/machine/decocpu6.cpp",
 	MAME_DIR .. "src/mame/machine/decocpu6.h",
+	MAME_DIR .. "src/mame/machine/deco_ace.cpp",
+	MAME_DIR .. "src/mame/machine/deco_ace.h",
 	MAME_DIR .. "src/mame/drivers/deco_ld.cpp",
 	MAME_DIR .. "src/mame/drivers/deco_mlc.cpp",
 	MAME_DIR .. "src/mame/includes/deco_mlc.h",


### PR DESCRIPTION
99 is Alpha/Palette effect chip from Data East.
Data East 99 Chip Used on:
boogwing.cpp (Boogie Wings/The Great Ragtime Show(Japan))
deco32.cpp (only used Tattoo Assassins/Night Slashers)